### PR TITLE
[bugfix] Resolved passing props issue

### DIFF
--- a/src/client/app/components/App.jsx
+++ b/src/client/app/components/App.jsx
@@ -33,7 +33,7 @@ class App extends Component {
           <div>
             <Route exact path="/" component={Home}/>
             <Route path="/search" component={Search}/>
-            <Route path="/draft" component={DraftSimulator}/>
+            <Route path="/draft" render={ () => <DraftSimulator cards={this.state.cards}/> }/>
           </div>
         </Router>
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -13,15 +13,15 @@ app.use(require('webpack-dev-middleware')(compiler, {
 }));
 app.use(require('webpack-hot-middleware')(compiler));
 
-// Redirect user back to index.html (used with react-router-dom)
-app.get('*', (req, res) => {
-  res.sendFile(path.resolve(__dirname, '..', 'client/index.html'));
-});
-
 // Render static index route
 app.use(express.static(path.join(__dirname, '../client')));
 
 // Routes
 app.get('/getCardData', getCardData);
+
+// Redirect user back to index.html (used with react-router-dom)
+app.get('*', (req, res) => {
+  res.sendFile(path.resolve(__dirname, '..', 'client/index.html'));
+});
 
 app.listen(port, () => { console.log(`server.js has been served on port: ${port}`); });


### PR DESCRIPTION
The API call to `getCardData` wasn't getting the data from S3. I had to move the server side redirect to `index.html` under the API end point routes so it would redirect _if_ the route wasn't found.